### PR TITLE
Add `bin/setup` script for development

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+
+GEM_ROOT = File.expand_path("..", __dir__)
+
+def system!(*args)
+  system(*args, exception: true)
+end
+
+FileUtils.chdir GEM_ROOT do
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
+  # Add necessary setup steps to this file.
+
+  puts "== Installing dependencies =="
+  system("bundle check") || system!("bundle install")
+end


### PR DESCRIPTION
### Background

`bin/setup` is the default way for anyone in a Rails project to setup their dev environment in terms of installing dependencies, making sure the database is setup, etc. We shouldn't be installing tooling via package managers (but perhaps detect & output if missing?).

### Detail

- [x] Add `bin/setup` to install bundler dependencies