### PR TITLE
Fix: Silence ActiveSupport::Configurable deprecation warning

### DIFF
--- a/lib/panda/core/engine.rb
+++ b/lib/panda/core/engine.rb
@@ -2,7 +2,15 @@ require "rubygems"
 
 require "rails/engine"
 require "omniauth"
-require "omniauth/rails_csrf_protection"
+
+# Silence ActiveSupport::Configurable deprecation from omniauth-rails_csrf_protection
+# This gem uses the deprecated module but hasn't been updated yet
+# Issue: https://github.com/cookpad/omniauth-rails_csrf_protection/issues/23
+# This can be removed once the gem is updated or Rails 8.2 is released
+ActiveSupport::Deprecation.silence do
+  require "omniauth/rails_csrf_protection"
+end
+
 require "view_component"
 
 module Panda


### PR DESCRIPTION
## Summary

Silences the deprecation warning from the `omniauth-rails_csrf_protection` gem which still uses `ActiveSupport::Configurable` - a module deprecated in Rails 8.1 and scheduled for removal in Rails 8.2.

## Problem

Every Rails command shows this warning:
```
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.
```

The warning is caused by the `omniauth-rails_csrf_protection` gem (v1.0.2), which uses `ActiveSupport::Configurable` internally.

## Solution

Wrapped the gem's require statement in `ActiveSupport::Deprecation.silence` block:

```ruby
ActiveSupport::Deprecation.silence do
  require "omniauth/rails_csrf_protection"
end
```

This silences the warning without affecting functionality.

## Details

- **Issue tracker:** https://github.com/cookpad/omniauth-rails_csrf_protection/issues/23
- **Affected file:** `/lib/panda/core/engine.rb`
- **Temporary fix:** Yes - can be removed once gem is updated
- **Breaking changes:** None
- **Testing:** Verified no warnings appear with Rails commands

## Before

```bash
$ rails runner "puts 'test'"
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement...
test
```

## After

```bash
$ rails runner "puts 'test'"
test
```

## Future Action

Once the gem maintainers release a fix (expected to replace `ActiveSupport::Configurable` with `class_attribute`), we can:
1. Update to the new gem version
2. Remove this silence wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>