### PR TITLE
fix: Use ViewComponent slots for PanelComponent body content

### DIFF
--- a/app/components/panda/core/admin/panel_component.html.erb
+++ b/app/components/panda/core/admin/panel_component.html.erb
@@ -4,8 +4,8 @@
   <% end %>
 
   <div class="p-4 text-black bg-white rounded-b-lg">
-    <% if body_slot? %>
-      <%= body_slot %>
+    <% if body? %>
+      <%= body %>
     <% end %>
   </div>
 </div>

--- a/app/components/panda/core/admin/panel_component.rb
+++ b/app/components/panda/core/admin/panel_component.rb
@@ -8,24 +8,16 @@ module Panda
           Panda::Core::Admin::HeadingComponent.new(**props.merge(level: :panel))
         }
 
-        def initialize(**attrs, &block)
+        renders_one :body
+
+        def initialize(**attrs)
           super(**attrs)
-          @body_content = nil
-          # Execute the block to capture DSL calls
-          yield self if block_given?
         end
 
-        def body(&block)
-          @body_content = block if block_given?
-          @body_content
-        end
-
-        def body_slot?
-          @body_content.present?
-        end
-
-        def body_slot
-          @body_content&.call
+        # Aliases for backward compatibility
+        # Supports: panel.heading(text: "Title") as alias for panel.with_heading_slot(text: "Title")
+        def heading(**props)
+          with_heading_slot(**props)
         end
       end
     end

--- a/spec/components/panda/core/admin/panel_component_spec.rb
+++ b/spec/components/panda/core/admin/panel_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Panda::Core::Admin::PanelComponent, type: :component do
     it "renders a panel with heading and body" do
       render_inline(described_class.new) do |panel|
         panel.with_heading_slot(text: "Recent Activity")
-        panel.body { "Activity content goes here" }
+        panel.with_body { "Activity content goes here" }
       end
       output = Capybara.string(rendered_content)
 
@@ -18,7 +18,7 @@ RSpec.describe Panda::Core::Admin::PanelComponent, type: :component do
 
     it "renders panel without heading" do
       render_inline(described_class.new) do |panel|
-        panel.body { "Just body content" }
+        panel.with_body { "Just body content" }
       end
       output = Capybara.string(rendered_content)
 


### PR DESCRIPTION
## Summary
- Fix rendering bug where HTML closing tags (`</tbody> </table> </div>`) were being displayed as text at the bottom of dashboard panels
- Replace custom block capture mechanism with ViewComponent's proper `renders_one :body` slot
- Add backwards-compatible `heading()` alias method

## Test plan
- [x] PanelComponent tests pass
- [x] PopularPagesComponent tests pass
- [ ] Verify on staging that dashboard no longer shows raw HTML tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)