### PR TITLE
Fix ViewComponent slot method names in admin views

### DIFF
--- a/app/views/panda/core/admin/dashboard/show.html.erb
+++ b/app/views/panda/core/admin/dashboard/show.html.erb
@@ -1,7 +1,7 @@
 <div class="" data-controller="dashboard">
   <% container = Panda::Core::Admin::ContainerComponent.new %>
-  <% container.with_heading(text: "Dashboard", level: 1) %>
-  <% container.with_body do %>
+  <% container.with_heading_slot(text: "Dashboard", level: 1) %>
+  <% container.with_body_slot do %>
     <%# Hook for dashboard widgets %>
     <% if Panda::Core.config.admin_dashboard_widgets %>
       <% widgets = Panda::Core.config.admin_dashboard_widgets.call(current_user) %>

--- a/app/views/panda/core/admin/my_profile/edit.html.erb
+++ b/app/views/panda/core/admin/my_profile/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render Panda::Core::Admin::ContainerComponent.new do |component| %>
-  <% component.with_heading(text: "My Profile", level: 1) %>
+  <% component.with_heading_slot(text: "My Profile", level: 1) %>
 
   <%= form_with model: user,
               url: admin_my_profile_path,

--- a/app/views/panda/core/admin/my_profile/logins/show.html.erb
+++ b/app/views/panda/core/admin/my_profile/logins/show.html.erb
@@ -3,8 +3,8 @@
 
   <!-- Connected Accounts -->
   <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
-    <% panel.heading(text: "Connected Accounts", meta: "Manage your OAuth authentication providers") %>
-    <% panel.body do %>
+    <% panel.with_heading_slot(text: "Connected Accounts", meta: "Manage your OAuth authentication providers") %>
+    <% panel.with_body_slot do %>
       <div class="space-y-4">
         <% enabled_providers = Panda::Core.config.authentication_providers %>
         <% if enabled_providers.empty? %>
@@ -23,8 +23,8 @@
 
   <!-- Login History -->
   <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
-    <% panel.heading(text: "Login History", meta: "Recent login activity for your account") %>
-    <% panel.body do %>
+    <% panel.with_heading_slot(text: "Login History", meta: "Recent login activity for your account") %>
+    <% panel.with_body_slot do %>
       <div class="space-y-4">
         <p class="text-sm text-gray-500">Login history tracking will be implemented in a future release.</p>
         <!-- Future implementation:
@@ -38,8 +38,8 @@
 
   <!-- Two-Factor Authentication (Future) -->
   <%= render Panda::Core::Admin::PanelComponent.new do |panel| %>
-    <% panel.heading(text: "Two-Factor Authentication", meta: "Add an extra layer of security to your account") %>
-    <% panel.body do %>
+    <% panel.with_heading_slot(text: "Two-Factor Authentication", meta: "Add an extra layer of security to your account") %>
+    <% panel.with_body_slot do %>
       <div class="space-y-4">
         <p class="text-sm text-gray-500">
           Two-factor authentication will be available in a future release.


### PR DESCRIPTION
## Summary
- Fix slot method calls in admin views to match ViewComponent's naming convention
- Change `with_heading(...)` → `with_heading_slot(...)`
- Change `with_body do` → `with_body_slot do`  
- Change `heading(...)` → `with_heading_slot(...)`
- Change `body do` → `with_body_slot do`

## Files Changed
- `app/views/panda/core/admin/dashboard/show.html.erb`
- `app/views/panda/core/admin/my_profile/edit.html.erb`
- `app/views/panda/core/admin/my_profile/logins/show.html.erb`

## Test plan
- [x] Component tests pass (273 examples, 0 failures)
- [ ] Verify admin dashboard renders correctly
- [ ] Verify My Profile page renders correctly
- [ ] Verify Login & Security page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)