### PR TITLE
Fix double button rendering in HeadingComponent via slots

### DIFF
--- a/app/components/panda/core/admin/container_component.rb
+++ b/app/components/panda/core/admin/container_component.rb
@@ -4,8 +4,8 @@ module Panda
   module Core
     module Admin
       class ContainerComponent < Panda::Core::Base
-        renders_one :heading_slot, lambda { |text: "", icon: "", meta: nil, level: 2, **attrs, &block|
-          Panda::Core::Admin::HeadingComponent.new(text: text, icon: icon, meta: meta, level: level, **attrs, &block)
+        renders_one :heading_slot, lambda { |text: "", icon: "", meta: nil, level: 2, **attrs|
+          Panda::Core::Admin::HeadingComponent.new(text: text, icon: icon, meta: meta, level: level, **attrs)
         }
         renders_one :tab_bar_slot, lambda { |tabs: [], **attrs|
           Panda::Core::Admin::TabBarComponent.new(tabs: tabs, **attrs)

--- a/app/components/panda/core/admin/heading_component.rb
+++ b/app/components/panda/core/admin/heading_component.rb
@@ -14,14 +14,11 @@ module Panda
           @meta = meta
           @level = level
           @additional_styles = additional_styles
-          @block_executed = false
-          # Call super WITHOUT passing the block to prevent ViewComponent from capturing it as content
           super(**attrs)
-          # Execute the block once to register buttons via DSL
-          if block_given?
-            yield self
-            @block_executed = true
-          end
+          # Execute the block to register buttons via DSL (for direct usage)
+          # Note: When used via ContainerComponent's heading_slot, the block is NOT passed here
+          # to prevent double execution (ViewComponent also yields to the block)
+          yield self if block_given?
         end
 
         attr_reader :text, :icon, :meta, :level


### PR DESCRIPTION
## Summary
Fix duplicate "Add Page" buttons appearing on the dashboard and other pages using HeadingComponent via ContainerComponent slots.

## Problem
When HeadingComponent is used through ContainerComponent's `heading_slot`, buttons were being registered twice:
1. Once in HeadingComponent's `initialize` (via `yield self`)
2. Again by ViewComponent's slot system (which also yields the component to the block)

## Solution
- Don't forward the block (`&block`) from the `heading_slot` lambda to HeadingComponent
- ViewComponent automatically yields the created component to the block
- HeadingComponent's `initialize` still executes the block for direct usage (not via slots)

## Test plan
- [x] All 273 component tests pass
- [ ] Verify dashboard shows single "Add Page" button
- [ ] Verify pages index shows single "Add Page" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)