### PR TITLE
Fix field_id method shadowed by FormTagHelper include

### DIFF
--- a/app/builders/panda/core/form_builder.rb
+++ b/app/builders/panda/core/form_builder.rb
@@ -10,6 +10,12 @@ module Panda
         super(attribute, text, options.reverse_merge(class: label_styles))
       end
 
+      # Override field_id to match FormBuilder's signature, since the included
+      # FormTagHelper defines a field_id with a different arity that shadows it.
+      def field_id(method, *suffixes, namespace: @options[:namespace], index: @options[:index])
+        @template.field_id(@object_name, method, *suffixes, namespace: namespace, index: index)
+      end
+
       def text_field(attribute, options = {})
         # Extract custom label if provided
         custom_label = options.delete(:label)


### PR DESCRIPTION
## Summary
- The `FormBuilder` includes `FormTagHelper` which defines `field_id(object_name, method_name, ...)` — a different signature than the parent `FormBuilder#field_id(method, ...)`
- When views call `f.field_id(:avatar)`, Ruby resolves to the `FormTagHelper` version (needs 2+ args) instead of the `FormBuilder` version (needs 1 arg), causing `ArgumentError`
- Adds an explicit `field_id` override on the class that delegates to `@template.field_id` with the correct arguments

## Test plan
- [x] Verified `My Profile` page no longer raises JavaScript errors in panda-cms system tests
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)