### PR TITLE
Add broken image fallback to file gallery

### DIFF
--- a/app/components/panda/core/admin/file_gallery_component.html.erb
+++ b/app/components/panda/core/admin/file_gallery_component.html.erb
@@ -11,7 +11,10 @@
               <%= tag.img src: url_for(file),
                   alt: file.filename.to_s,
                   class: file_image_classes(is_selected),
-                  onerror: "this.onerror=null;this.parentNode.innerHTML='<div class=\"flex items-center justify-center h-full bg-gray-100 dark:bg-gray-700\"><i class=\"fa-solid fa-file-image text-4xl text-gray-400\"></i></div>'" %>
+                  onerror: "this.onerror=null;this.style.display='none';this.nextElementSibling.classList.remove('hidden')" %>
+              <div class="hidden flex items-center justify-center h-full bg-gray-100 dark:bg-gray-700" role="img" aria-label="Image preview not available">
+                <i class="fa-solid fa-file-image text-4xl text-gray-400"></i>
+              </div>
             <% else %>
               <%# File icon placeholder - implement based on file type %>
               <div class="flex items-center justify-center h-full bg-gray-100 dark:bg-gray-700">


### PR DESCRIPTION
## Summary
- Adds an `onerror` handler to `<img>` tags in the file gallery component
- When images fail to load (misconfigured CDN, purged files, 404s), the browser's broken image icon is replaced with a clean Font Awesome `fa-file-image` placeholder
- Matches the existing non-image file display style already in the template

## Test plan
- [ ] Upload an image, then manually delete its backing file from storage — verify the gallery shows a clean placeholder instead of a broken image icon
- [ ] Verify non-image files still display correctly with their existing icon
- [ ] Run `bundle exec rspec` in panda-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)