### PR TITLE
Remove flaky tags from all system tests

### DIFF
--- a/spec/system/panda/core/admin/logout_spec.rb
+++ b/spec/system/panda/core/admin/logout_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-RSpec.describe "Admin logout", type: :system, flaky: true do
+RSpec.describe "Admin logout", type: :system do
   let(:admin_user) { create_admin_user }
 
   before do

--- a/spec/system/panda/core/admin/my_profile/logins_spec.rb
+++ b/spec/system/panda/core/admin/my_profile/logins_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-RSpec.describe "Admin My Profile Logins", type: :system, flaky: true do
+RSpec.describe "Admin My Profile Logins", type: :system do
   let!(:admin_user) { create_admin_user }
 
   before do

--- a/spec/system/panda/core/admin/nested_navigation_spec.rb
+++ b/spec/system/panda/core/admin/nested_navigation_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "Nested navigation", type: :system do
       end
     end
 
-    it "expands parent menu automatically when child is active", :flaky, js: true do
+    it "expands parent menu automatically when child is active", js: true do
       visit "/admin/settings"
 
       # The Settings menu should be automatically expanded


### PR DESCRIPTION
## Summary
- Removes `:flaky` tags from logout, logins, and nested navigation auto-expand tests
- All three tests will now run in the stable suite to verify they pass in CI

## Test plan
- [ ] CI stable suite passes with these tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)