### PR TITLE
Add pluggable authorization infrastructure for RBAC

### DIFF
--- a/app/controllers/concerns/panda/core/authorizable.rb
+++ b/app/controllers/concerns/panda/core/authorizable.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Panda
+  module Core
+    # Authorizable concern for admin controllers.
+    #
+    # Provides a generic authorization layer that delegates permission checks
+    # to the configurable `Panda::Core.config.authorization_policy` lambda.
+    # This allows downstream gems (e.g. panda-cms-pro) to inject RBAC checks
+    # without panda-core needing any knowledge of roles or permissions.
+    #
+    # Usage in controllers:
+    #
+    #   class PagesController < Admin::BaseController
+    #     require_permission :edit_content, only: [:edit, :update]
+    #     require_permission :publish_content, only: [:publish]
+    #   end
+    #
+    # Or manually:
+    #
+    #   def update
+    #     authorize!(:edit_content, @page)
+    #   end
+    #
+    module Authorizable
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :can? if respond_to?(:helper_method)
+      end
+
+      class_methods do
+        # DSL for declarative permission checks.
+        # Registers a before_action that calls authorize! for the given permission.
+        #
+        # @param permission [Symbol] the permission key to check
+        # @param options [Hash] standard before_action options (only:, except:, etc.)
+        def require_permission(permission, **options)
+          before_action(**options) do
+            authorize!(permission)
+          end
+        end
+      end
+
+      # Check whether the current user is authorized for the given action.
+      #
+      # @param action [Symbol] the action/permission to check
+      # @param resource [Object, nil] optional resource context
+      # @return [Boolean]
+      def authorized_for?(action, resource = nil)
+        return false unless current_user
+
+        # Admin users bypass all authorization checks
+        return true if current_user.admin?
+
+        # Delegate to the configured authorization policy
+        policy = Panda::Core.config.authorization_policy
+        policy.call(current_user, action, resource)
+      end
+
+      # Authorize the current user or render a 403/redirect.
+      #
+      # @param action [Symbol] the action/permission to check
+      # @param resource [Object, nil] optional resource context
+      # @raise renders 403 or redirects if not authorized
+      def authorize!(action, resource = nil)
+        return if authorized_for?(action, resource)
+
+        respond_to do |format|
+          format.html do
+            flash[:error] = "You do not have permission to perform this action."
+            redirect_to(request.referer || panda_core.admin_root_path)
+          end
+          format.json do
+            render json: {error: "Forbidden", status: 403}, status: :forbidden
+          end
+        end
+      end
+
+      # View-layer helper for checking permissions.
+      # Can be used in templates: `if can?(:edit_content)`
+      #
+      # @param action [Symbol] the action/permission to check
+      # @param resource [Object, nil] optional resource context
+      # @return [Boolean]
+      def can?(action, resource = nil)
+        authorized_for?(action, resource)
+      end
+
+      # Check whether the current user is authorized to access the admin panel.
+      # This is called during authentication to allow non-admin users with roles
+      # to access the admin area.
+      #
+      # @return [Boolean]
+      def authorized_for_admin_access?
+        return false unless current_user
+
+        # Admin users always have access
+        return true if current_user.admin?
+
+        # Check the authorization policy for :access_admin
+        policy = Panda::Core.config.authorization_policy
+        policy.call(current_user, :access_admin, nil)
+      end
+    end
+  end
+end

--- a/app/controllers/panda/core/admin/base_controller.rb
+++ b/app/controllers/panda/core/admin/base_controller.rb
@@ -6,6 +6,8 @@ module Panda
       # Base controller for all admin interfaces across Panda gems
       # Provides authentication, helpers, and hooks for extending functionality
       class BaseController < ::ActionController::Base
+        include Panda::Core::Authorizable
+
         layout "panda/core/admin"
 
         protect_from_forgery with: :exception
@@ -50,10 +52,16 @@ module Panda
         end
 
         def authenticate_admin_user!
-          return if user_signed_in? && current_user.admin?
+          unless user_signed_in?
+            redirect_to panda_core.admin_login_path,
+              flash: {error: "Please login to view this!"}
+            return
+          end
+
+          return if authorized_for_admin_access?
 
           redirect_to panda_core.admin_login_path,
-            flash: {error: "Please login to view this!"}
+            flash: {error: "You are not authorized to access the admin area."}
         end
 
         # Required for paper_trail and seems as good as convention these days

--- a/app/controllers/panda/core/admin/sessions_controller.rb
+++ b/app/controllers/panda/core/admin/sessions_controller.rb
@@ -31,8 +31,12 @@ module Panda
           user = User.find_or_create_from_auth_hash(auth)
 
           if user.persisted?
-            # Check if user is admin before allowing access
-            unless user.admin?
+            # Check if user is authorized to access the admin area.
+            # Admin users always have access. Non-admin users are checked
+            # via the configurable authorization_policy (e.g. role-based access
+            # from panda-cms-pro).
+            policy = Panda::Core.config.authorization_policy
+            unless user.admin? || policy.call(user, :access_admin, nil)
               flash[:error] = "You do not have permission to access the admin area"
               flash.keep(:error) if Rails.env.test?
               redirect_to admin_login_path

--- a/docs/authentication/authorization.md
+++ b/docs/authentication/authorization.md
@@ -1,0 +1,109 @@
+# Authorization
+
+Panda Core provides a pluggable authorization layer that allows downstream gems to inject permission checks into the admin interface.
+
+## Overview
+
+By default, only users with `admin? == true` can access the admin panel. The authorization system extends this by allowing a configurable **authorization policy** that can grant access to non-admin users based on roles, permissions, or any custom logic.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│ Panda::Core::Admin::BaseController          │
+│   includes Panda::Core::Authorizable        │
+│                                             │
+│   authenticate_admin_user!                  │
+│     → user_signed_in?                       │
+│     → authorized_for_admin_access?          │
+│         → admin? (bypass)                   │
+│         → authorization_policy(:access_admin)│
+└─────────────────────────────────────────────┘
+         ↓ delegated to
+┌─────────────────────────────────────────────┐
+│ Panda::Core.config.authorization_policy     │
+│   ->(user, action, resource) { ... }        │
+│                                             │
+│   Default: user.admin?                      │
+│   Pro:     role-based permission checks     │
+└─────────────────────────────────────────────┘
+```
+
+## The Authorizable Concern
+
+`Panda::Core::Authorizable` is included in `Panda::Core::Admin::BaseController` and provides:
+
+### `authorized_for?(action, resource = nil)`
+
+Checks whether the current user is authorized for the given action. Admin users bypass all checks. For non-admin users, delegates to `Panda::Core.config.authorization_policy`.
+
+### `authorize!(action, resource = nil)`
+
+Calls `authorized_for?` and renders a 403/redirect if the user is not authorized. Use this in controller actions for manual permission checks.
+
+### `can?(action, resource = nil)`
+
+View-layer helper (exposed via `helper_method`) for checking permissions in templates:
+
+```erb
+<% if can?(:edit_content) %>
+  <%= link_to "Edit", edit_page_path(@page) %>
+<% end %>
+```
+
+### `authorized_for_admin_access?`
+
+Checks whether the current user is authorized to access the admin panel at all. Used by `authenticate_admin_user!`.
+
+### `require_permission` (class method DSL)
+
+Declarative permission checks on controller actions:
+
+```ruby
+class MyController < Panda::Core::Admin::BaseController
+  require_permission :edit_content, only: [:edit, :update]
+  require_permission :delete_content, only: [:destroy]
+end
+```
+
+## Configuring the Authorization Policy
+
+The authorization policy is a lambda that receives `(user, action, resource)` and returns a boolean:
+
+```ruby
+Panda::Core.configure do |config|
+  config.authorization_policy = ->(user, action, resource) {
+    case action
+    when :access_admin
+      user.has_any_role?
+    else
+      user.has_permission?(action)
+    end
+  }
+end
+```
+
+### Default Policy
+
+The default policy simply checks `user.admin?`:
+
+```ruby
+config.authorization_policy = ->(user, action, resource) { user.admin? }
+```
+
+### With Panda CMS Pro
+
+When panda-cms-pro is loaded, it automatically sets the authorization policy to support role-based access:
+
+- `:access_admin` — returns `true` if the user has any active role assignment
+- Other actions — delegates to `user.has_permission?(action)` which checks all of the user's role assignments
+
+## Session Controller Integration
+
+The sessions controller (`Panda::Core::Admin::SessionsController`) also respects the authorization policy during login. When a user authenticates via OAuth, the controller checks:
+
+1. Is the user an admin? → Allow login
+2. Does the authorization policy grant `:access_admin`? → Allow login
+3. Neither → Reject with "You do not have permission to access the admin area"
+
+This ensures that non-admin users with roles can log in, while users with no roles are still blocked.

--- a/spec/controllers/concerns/panda/core/authorizable_spec.rb
+++ b/spec/controllers/concerns/panda/core/authorizable_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Panda::Core::Authorizable do
+  # Create a test controller class that includes the concern
+  let(:controller_class) do
+    Class.new(ActionController::Base) do
+      include Panda::Core::Authorizable
+
+      # Stub current_user method
+      attr_accessor :_current_user
+
+      def current_user
+        _current_user
+      end
+    end
+  end
+
+  let(:controller) { controller_class.new }
+  let(:admin_user) { create_admin_user }
+  let(:regular_user) { create_regular_user }
+
+  before do
+    # Reset to default policy before each test
+    Panda::Core.config.authorization_policy = ->(user, action, resource) { user.admin? }
+  end
+
+  after do
+    Panda::Core.reset_config!
+  end
+
+  describe "#authorized_for?" do
+    context "with no current user" do
+      it "returns false" do
+        controller._current_user = nil
+        expect(controller.authorized_for?(:edit_content)).to be false
+      end
+    end
+
+    context "with an admin user" do
+      it "returns true for any action" do
+        controller._current_user = admin_user
+        expect(controller.authorized_for?(:edit_content)).to be true
+        expect(controller.authorized_for?(:manage_roles)).to be true
+        expect(controller.authorized_for?(:nonexistent_permission)).to be true
+      end
+    end
+
+    context "with a non-admin user and default policy" do
+      it "returns false" do
+        controller._current_user = regular_user
+        expect(controller.authorized_for?(:edit_content)).to be false
+      end
+    end
+
+    context "with a non-admin user and custom policy" do
+      before do
+        Panda::Core.config.authorization_policy = ->(user, action, _resource) {
+          action == :edit_content
+        }
+      end
+
+      it "delegates to the custom policy" do
+        controller._current_user = regular_user
+        expect(controller.authorized_for?(:edit_content)).to be true
+        expect(controller.authorized_for?(:manage_roles)).to be false
+      end
+    end
+
+    context "with a resource parameter" do
+      it "passes the resource to the policy" do
+        resource = double("Page")
+        received_resource = nil
+        Panda::Core.config.authorization_policy = ->(user, action, res) {
+          received_resource = res
+          true
+        }
+
+        controller._current_user = regular_user
+        controller.authorized_for?(:edit_content, resource)
+        expect(received_resource).to eq(resource)
+      end
+    end
+  end
+
+  describe "#can?" do
+    it "is an alias for authorized_for?" do
+      controller._current_user = admin_user
+      expect(controller.can?(:anything)).to be true
+
+      controller._current_user = regular_user
+      expect(controller.can?(:anything)).to be false
+    end
+  end
+
+  describe "#authorized_for_admin_access?" do
+    context "with no current user" do
+      it "returns false" do
+        controller._current_user = nil
+        expect(controller.authorized_for_admin_access?).to be false
+      end
+    end
+
+    context "with an admin user" do
+      it "returns true" do
+        controller._current_user = admin_user
+        expect(controller.authorized_for_admin_access?).to be true
+      end
+    end
+
+    context "with a non-admin user and default policy" do
+      it "returns false" do
+        controller._current_user = regular_user
+        expect(controller.authorized_for_admin_access?).to be false
+      end
+    end
+
+    context "with a custom policy that grants access_admin" do
+      before do
+        Panda::Core.config.authorization_policy = ->(user, action, _resource) {
+          action == :access_admin
+        }
+      end
+
+      it "returns true for non-admin users" do
+        controller._current_user = regular_user
+        expect(controller.authorized_for_admin_access?).to be true
+      end
+    end
+  end
+
+  describe ".require_permission" do
+    it "registers a before_action that calls authorize!" do
+      test_class = Class.new(ActionController::Base) do
+        include Panda::Core::Authorizable
+        require_permission :edit_content, only: [:edit, :update]
+      end
+
+      # Check that the before_action was registered
+      callbacks = test_class._process_action_callbacks.select { |c| c.kind == :before }
+      expect(callbacks).not_to be_empty
+    end
+  end
+end

--- a/spec/system/panda/core/admin/admin_pages_smoke_test_spec.rb
+++ b/spec/system/panda/core/admin/admin_pages_smoke_test_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Core admin pages smoke tests", type: :system do
 
   describe "Users management" do
     context "with a regular user" do
-      let!(:regular_user) { create_user }
+      let!(:regular_user) { create_regular_user }
 
       it "loads users index without errors" do
         visit "/admin/users"


### PR DESCRIPTION
## Summary
- Introduces `Panda::Core::Authorizable` concern providing a generic authorization layer that delegates permission checks to the configurable `authorization_policy` lambda
- Updates `authenticate_admin_user!` to use `authorized_for_admin_access?` which checks admin status first, then falls back to the policy — enabling non-admin users with roles to access the admin panel
- Updates sessions controller to allow role-based login via the authorization policy
- Fixes pre-existing `create_user` → `create_regular_user` bug in smoke test spec

## Key Changes

### New: `Authorizable` concern (`app/controllers/concerns/panda/core/authorizable.rb`)
- `authorized_for?(action, resource)` — admin bypass, then delegates to policy
- `authorize!(action, resource)` — 403/redirect if unauthorized
- `can?(action, resource)` — view-layer helper
- `require_permission` class method DSL for declarative checks
- `authorized_for_admin_access?` — used during authentication

### Modified: `base_controller.rb`
- Includes `Authorizable`, splits authentication (signed in?) from authorization (allowed?)

### Modified: `sessions_controller.rb`
- Non-admin users can now login if `authorization_policy(:access_admin)` returns true

### Documentation
- New `docs/authentication/authorization.md`

## Test plan
- [x] 11 new specs for Authorizable concern (all pass)
- [x] Full panda-core test suite passes (591 examples, 0 new failures)
- [x] Smoke test fix verified (12 examples, 0 failures)
- [ ] Manual test: admin login still works
- [ ] Manual test: non-admin without roles still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)