### PR TITLE
Fix FormBuilder crash when form has no model object

### DIFF
--- a/app/builders/panda/core/form_builder.rb
+++ b/app/builders/panda/core/form_builder.rb
@@ -286,7 +286,7 @@ module Panda
         value ||= submit_default_value
 
         # Use the primary color for save/create actions
-        action = object.persisted? ? :save : :create
+        action = object&.persisted? ? :save : :create
         button_classes = case action
         when :save, :create
           "text-white bg-primary-500 hover:bg-primary-600"
@@ -407,7 +407,13 @@ module Panda
       end
 
       def submit_default_value
-        object.persisted? ? "Update #{object.class.name.demodulize}" : "Create #{object.class.name.demodulize}"
+        if object.nil?
+          "Submit"
+        elsif object.persisted?
+          "Update #{object.class.name.demodulize}"
+        else
+          "Create #{object.class.name.demodulize}"
+        end
       end
 
       def wrap_field(method, options = {}, &block)

--- a/spec/builders/panda/core/form_builder_spec.rb
+++ b/spec/builders/panda/core/form_builder_spec.rb
@@ -224,6 +224,50 @@ RSpec.describe Panda::Core::FormBuilder, type: :helper do
     end
   end
 
+  describe "#submit" do
+    context "with a model object" do
+      it "renders a submit button with create text for new records" do
+        result = builder.submit
+        expect(result).to include("Create User")
+      end
+
+      it "renders a submit button with the given value" do
+        result = builder.submit("Save Changes")
+        expect(result).to include("Save Changes")
+      end
+    end
+
+    context "without a model object (form_with url:)" do
+      let(:nil_builder) { described_class.new(nil, nil, template, {}) }
+
+      it "renders a submit button without raising an error" do
+        result = nil_builder.submit("Create Token")
+        expect(result).to include("Create Token")
+      end
+
+      it "uses 'Submit' as the default value when no value is given" do
+        result = nil_builder.submit
+        expect(result).to include("Submit")
+      end
+    end
+  end
+
+  describe "#button" do
+    context "without a model object (form_with url:)" do
+      let(:nil_builder) { described_class.new(nil, nil, template, {}) }
+
+      it "renders a button without raising an error" do
+        result = nil_builder.button("Create Token")
+        expect(result).to include("Create Token")
+      end
+
+      it "uses 'Submit' as the default value when no value is given" do
+        result = nil_builder.button
+        expect(result).to include("Submit")
+      end
+    end
+  end
+
   describe "backward compatibility" do
     it "does not break existing forms without custom labels" do
       text_result = builder.text_field(:name)


### PR DESCRIPTION
## Summary
- `FormBuilder#submit` calls `object.persisted?` unconditionally, which raises `NoMethodError` when using `form_with url:` (no model object)
- `#submit_default_value` has the same issue, also called by `#button`
- This causes a 500 error on any admin page with a URL-based form (e.g. the API tokens page in panda-cms-pro)

## Changes
- Add safe navigation (`&.`) in `submit` method for the `object.persisted?` call
- Add explicit nil check in `submit_default_value` — returns "Submit" when no model is present
- Add specs for `submit` and `button` with nil objects

## Test plan
- [x] All 32 FormBuilder specs pass (6 new)
- [ ] Verify `/manage/my_profile/api_tokens` no longer 500s after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)