### PR TITLE
Fix chartkick asset serving middleware

### DIFF
--- a/app/components/panda/core/shared/header_component.html.erb
+++ b/app/components/panda/core/shared/header_component.html.erb
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.1.0/css/all.min.css">
     <%= helpers.panda_core_stylesheet %>
 
-    <% if defined?(Chartkick::Engine) %>
+    <% if Gem.loaded_specs["chartkick"] %>
       <script src="/panda-core-assets/chartkick/Chart.bundle.js"></script>
       <script src="/panda-core-assets/chartkick/chartkick.js"></script>
     <% end %>

--- a/lib/panda/core/engine.rb
+++ b/lib/panda/core/engine.rb
@@ -74,10 +74,11 @@ module Panda
 
       #
       # Serve Chartkick vendor assets when the chartkick gem is available
-      # Adds a simple middleware that maps chartkick JS requests to the gem's vendor dir
+      # Must be inserted BEFORE Rack::Static so it handles chartkick requests
+      # before Rack::Static catches all /panda-core-assets/* paths and returns 404
       #
-      if defined?(Chartkick::Engine)
-        config.app_middleware.use(Panda::Core::ChartkickAssetMiddleware)
+      if Gem.loaded_specs["chartkick"]
+        config.app_middleware.insert_before(Rack::Static, Panda::Core::ChartkickAssetMiddleware)
       end
     end
   end

--- a/lib/panda/core/middleware.rb
+++ b/lib/panda/core/middleware.rb
@@ -151,7 +151,7 @@ module Panda
 
       def initialize(app)
         @app = app
-        @vendor_root = Chartkick::Engine.root.join("vendor/assets/javascripts")
+        @vendor_root = Pathname.new(Gem.loaded_specs["chartkick"].gem_dir).join("vendor/assets/javascripts")
       end
 
       def call(env)

--- a/spec/components/panda/core/shared/header_component_spec.rb
+++ b/spec/components/panda/core/shared/header_component_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Panda::Core::Shared::HeaderComponent, type: :component do
       expect(html).to include("bg-gradient-admin")
     end
 
-    context "when Chartkick::Engine is defined" do
+    context "when chartkick gem is loaded" do
       before do
-        stub_const("Chartkick::Engine", Class.new)
+        allow(Gem).to receive(:loaded_specs).and_return({"chartkick" => double("gem_spec")})
       end
 
       it "includes Chartkick script tags" do
@@ -74,9 +74,9 @@ RSpec.describe Panda::Core::Shared::HeaderComponent, type: :component do
       end
     end
 
-    context "when Chartkick::Engine is not defined" do
+    context "when chartkick gem is not loaded" do
       before do
-        hide_const("Chartkick::Engine") if defined?(Chartkick::Engine)
+        allow(Gem).to receive(:loaded_specs).and_return({})
       end
 
       it "does not include Chartkick script tags" do

--- a/spec/lib/panda/core/middleware_spec.rb
+++ b/spec/lib/panda/core/middleware_spec.rb
@@ -172,20 +172,20 @@ RSpec.describe Panda::Core::Middleware do
 
   describe Panda::Core::ChartkickAssetMiddleware do
     let(:downstream_app) { ->(env) { [404, {"Content-Type" => "text/plain"}, ["Not Found"]] } }
-    let(:vendor_dir) { Rails.root.join("tmp/chartkick_test_vendor") }
+    let(:fake_gem_dir) { Rails.root.join("tmp/chartkick_test_gem") }
+    let(:vendor_dir) { fake_gem_dir.join("vendor/assets/javascripts") }
 
     before do
       FileUtils.mkdir_p(vendor_dir)
       File.write(vendor_dir.join("chartkick.js"), "// chartkick stub")
       File.write(vendor_dir.join("Chart.bundle.js"), "// chart bundle stub")
 
-      engine_root = double("engine_root")
-      allow(engine_root).to receive(:join).with("vendor/assets/javascripts").and_return(vendor_dir)
-      stub_const("Chartkick::Engine", double("Chartkick::Engine", root: engine_root))
+      gem_spec = double("gem_spec", gem_dir: fake_gem_dir.to_s)
+      allow(Gem).to receive(:loaded_specs).and_return({"chartkick" => gem_spec})
     end
 
     after do
-      FileUtils.rm_rf(vendor_dir)
+      FileUtils.rm_rf(fake_gem_dir)
     end
 
     subject(:middleware) { described_class.new(downstream_app) }


### PR DESCRIPTION
## Summary
- Chartkick v5.x doesn't define `Chartkick::Engine`, so the conditional `defined?(Chartkick::Engine)` always failed — the middleware was never registered and the header template inconsistently emitted `<script>` tags for assets that couldn't be served
- `Rack::Static` (configured for `/panda-core-assets`) intercepted chartkick requests first and returned 404 before `ChartkickAssetMiddleware` could handle them
- Replaced all `Chartkick::Engine` references with `Gem.loaded_specs["chartkick"]` and resolved the gem's vendor directory via `Gem::Specification#gem_dir`
- Used `insert_before(Rack::Static, ...)` so chartkick middleware runs before `Rack::Static` claims the request

## Test plan
- [x] panda-core middleware specs pass (24 examples, 0 failures)
- [x] panda-core header component specs pass (10 examples, 0 failures)
- [x] panda-cms admin smoke tests pass with zero chartkick routing errors (previously every page load produced `ActionController::RoutingError` for both chartkick JS files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)