### PR TITLE
Fix avatar purge on replacement and improve avatar_url

### DIFF
--- a/app/models/panda/core/user.rb
+++ b/app/models/panda/core/user.rb
@@ -143,17 +143,16 @@ module Panda
       # @param size [Symbol] The variant size (:thumb, :small, :medium, :large, or nil for original)
       # @return [String, nil] The avatar URL or nil if no avatar available
       def avatar_url(size: nil)
-        if avatar.attached?
-          if size && [:thumb, :small, :medium, :large].include?(size)
-            Rails.application.routes.url_helpers.rails_blob_path(avatar.variant(size), only_path: true)
-          else
-            Rails.application.routes.url_helpers.rails_blob_path(avatar, only_path: true)
-          end
-        elsif self[:image_url].present?
-          self[:image_url]
+        return self[:image_url].presence unless avatar.attached?
+
+        helpers = Rails.application.routes.url_helpers
+        if size && [:thumb, :small, :medium, :large].include?(size)
+          helpers.rails_representation_path(avatar.variant(size), only_path: true)
+        else
+          helpers.rails_blob_path(avatar.blob, only_path: true)
         end
       rescue => e
-        Rails.logger.error("Error generating avatar URL for user #{id}: #{e.message}")
+        Rails.logger.error("Error generating avatar URL for user #{id}: #{e.message}\n#{e.backtrace&.first(3)&.join("\n")}")
         self[:image_url].presence
       end
 


### PR DESCRIPTION
## Summary
- Explicitly purge old avatar blob in `MyProfileController#update` before attaching replacement, preventing orphaned blobs that show as "in use" on the Files page
- Fix `avatar_url` to use `rails_representation_path` for variants and explicit `avatar.blob` reference instead of proxy delegation
- Add backtrace to avatar URL error logging for better staging diagnostics

## Test plan
- [x] All 713 panda-core specs pass (0 failures)
- [ ] Upload avatar via My Profile → verify old blob is purged from DB and storage
- [ ] Verify avatar displays correctly in nav bar and profile page
- [ ] Verify variant URLs generate correctly for all sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)