### PR TITLE
feat(auth): Add post_authentication_redirect hook

### DIFF
--- a/app/controllers/panda/core/admin/sessions_controller.rb
+++ b/app/controllers/panda/core/admin/sessions_controller.rb
@@ -68,6 +68,22 @@ module Panda
               user: user,
               provider: provider)
 
+            # Post-authentication redirect hook (e.g. workspace picker).
+            # Wrapped in its own rescue so a broken hook falls through to the
+            # default redirect rather than hitting the outer rescue (which
+            # would redirect to login with the session already created).
+            if (redirect_proc = Panda::Core.config.post_authentication_redirect)
+              begin
+                redirect_url = redirect_proc.call(user, request)
+                if redirect_url.present?
+                  redirect_to redirect_url, allow_other_host: true, flash: {success: "Successfully logged in as #{user.name}"}
+                  return
+                end
+              rescue => e
+                Rails.logger.error "post_authentication_redirect hook failed: #{e.class}: #{e.message}"
+              end
+            end
+
             # Redirect to originating subdomain if auth callback landed on root domain
             origin = session.delete(:origin_subdomain)
             if origin.present? && request.host.split(".").first != origin

--- a/lib/panda/core/configuration.rb
+++ b/lib/panda/core/configuration.rb
@@ -49,7 +49,8 @@ module Panda
         :admin_user_index_columns,
         :restrict_user_creation,
         :after_user_invited,
-        :invite_form_content
+        :invite_form_content,
+        :post_authentication_redirect
 
       def initialize
         @user_class = "Panda::Core::User"
@@ -152,6 +153,11 @@ module Panda
         # Invitation hooks — host app can extend the invite flow
         @after_user_invited = nil        # Proc(user, params, current_user) — called after successful invite
         @invite_form_content = nil       # Proc(form_builder, view_context) → HTML — extra fields in invite form
+
+        # Post-authentication redirect — Proc(user, request) → URL string or nil.
+        # Called after successful OAuth login. Return a URL to redirect there,
+        # or nil to fall through to the default redirect logic.
+        @post_authentication_redirect = nil
 
         # Legacy extensible user menu items (prefer NavigationRegistry with position: :bottom)
         @admin_user_menu_items = []

--- a/spec/requests/panda/core/admin/sessions_spec.rb
+++ b/spec/requests/panda/core/admin/sessions_spec.rb
@@ -230,6 +230,76 @@ RSpec.describe "Admin Sessions", type: :request do
         expect(response).to redirect_to(panda_core.admin_login_path)
       end
     end
+
+    context "when post_authentication_redirect is configured" do
+      before do
+        @original_redirect = Panda::Core.config.post_authentication_redirect
+      end
+
+      after do
+        Panda::Core.config.post_authentication_redirect = @original_redirect
+      end
+
+      it "redirects to the URL returned by the hook" do
+        Panda::Core.config.post_authentication_redirect = ->(_user, _request) { "https://workspace.example.com/admin" }
+
+        mock_oauth_for_user(admin_user, provider: :google_oauth2)
+        post "/admin/auth/google_oauth2/callback", env: {"omniauth.auth" => OmniAuth.config.mock_auth[:google_oauth2]}
+
+        expect(session[Panda::Core::ADMIN_SESSION_KEY]).to eq(admin_user.id)
+        expect(flash[:success]).to eq("Successfully logged in as #{admin_user.name}")
+        expect(response).to redirect_to("https://workspace.example.com/admin")
+      end
+
+      it "falls through to default redirect when the hook returns nil" do
+        Panda::Core.config.post_authentication_redirect = ->(_user, _request) { nil }
+
+        mock_oauth_for_user(admin_user, provider: :google_oauth2)
+        post "/admin/auth/google_oauth2/callback", env: {"omniauth.auth" => OmniAuth.config.mock_auth[:google_oauth2]}
+
+        expect(session[Panda::Core::ADMIN_SESSION_KEY]).to eq(admin_user.id)
+        expect(flash[:success]).to eq("Successfully logged in as #{admin_user.name}")
+        expect(response).to redirect_to(panda_core.admin_root_path)
+      end
+
+      it "passes user and request to the hook" do
+        received_user = nil
+        received_request = nil
+        Panda::Core.config.post_authentication_redirect = ->(user, request) {
+          received_user = user
+          received_request = request
+          nil
+        }
+
+        mock_oauth_for_user(admin_user, provider: :google_oauth2)
+        post "/admin/auth/google_oauth2/callback", env: {"omniauth.auth" => OmniAuth.config.mock_auth[:google_oauth2]}
+
+        expect(received_user).to eq(admin_user)
+        expect(received_request).to be_a(ActionDispatch::Request)
+      end
+
+      it "falls through to default redirect when the hook raises" do
+        Panda::Core.config.post_authentication_redirect = ->(_user, _request) { raise "broken hook" }
+
+        mock_oauth_for_user(admin_user, provider: :google_oauth2)
+        post "/admin/auth/google_oauth2/callback", env: {"omniauth.auth" => OmniAuth.config.mock_auth[:google_oauth2]}
+
+        expect(session[Panda::Core::ADMIN_SESSION_KEY]).to eq(admin_user.id)
+        expect(response).to redirect_to(panda_core.admin_root_path)
+      end
+    end
+
+    context "when post_authentication_redirect is not configured" do
+      it "uses default redirect behaviour" do
+        Panda::Core.config.post_authentication_redirect = nil
+
+        mock_oauth_for_user(admin_user, provider: :google_oauth2)
+        post "/admin/auth/google_oauth2/callback", env: {"omniauth.auth" => OmniAuth.config.mock_auth[:google_oauth2]}
+
+        expect(session[Panda::Core::ADMIN_SESSION_KEY]).to eq(admin_user.id)
+        expect(response).to redirect_to(panda_core.admin_root_path)
+      end
+    end
   end
 
   describe "GET /admin/auth/failure" do


### PR DESCRIPTION
## Summary
- Adds `config.post_authentication_redirect` — a `Proc(user, request)` that host apps can set to override the default post-login redirect
- Called in `SessionsController#create` after session creation, before the existing `origin_subdomain` redirect logic
- Returns a URL string to redirect there, or `nil` to fall through to existing behaviour
- Uses `allow_other_host: true` for cross-subdomain redirects (e.g. workspace pickers in multi-tenant apps)

## Motivation
Alder CRM is rearchitecting its multi-tenant auth flow to be tenant-agnostic (authenticate identity first, route to workspace second). This hook lets the host app inject a workspace picker redirect without forking the sessions controller.

## Test plan
- [x] Spec: hook configured and returns URL → redirects there
- [x] Spec: hook configured and returns nil → falls through to default
- [x] Spec: hook passes correct user and request arguments
- [x] Spec: hook not configured → default behaviour unchanged
- [x] Full suite: 1090 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)