### PR TITLE
Fix auto-release trigger: point workflow_run at the renamed CI workflow

### DIFF
--- a/.github/workflows/auto-release-gem.yml
+++ b/.github/workflows/auto-release-gem.yml
@@ -3,7 +3,7 @@ name: 'Auto Release on Version Change'
 
 'on': # yamllint disable-line rule:truthy
   workflow_run:
-    workflows: ['App Tests']
+    workflows: ['CI']
     branches: [main]
     types: [completed]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-07-17
+
+### Fixed
+
+- Auto-release workflow's `workflow_run` trigger referenced the test
+  workflow's old name (`App Tests`); it now matches the current `CI`
+  workflow, so gem releases fire automatically again when `version.rb`
+  changes land on `main` (releases had required manual dispatch since the
+  rename)
+
 ## [1.1.0] - 2026-07-17
 
 ### Added

--- a/lib/panda/core/version.rb
+++ b/lib/panda/core/version.rb
@@ -2,6 +2,6 @@
 
 module Panda
   module Core
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
The auto-release workflow's `workflow_run` trigger still referenced **App Tests** — the test workflow's name before it became **CI** — so version-change releases have silently required manual dispatch ever since the rename (v0.12.x and v1.1.0 were all `workflow_dispatch` runs).

One-line trigger fix plus a bump to 1.1.1, so merging this PR doubles as the end-to-end proof: the CI run for the merge commit should fire the auto-release and tag v1.1.1 with no manual step.