### PR TITLE
Sync Gemfile.lock with the 1.1.1 version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panda-core (1.1.0)
+    panda-core (1.1.1)
       csv
       image_processing (~> 1.2)
       importmap-rails


### PR DESCRIPTION
The 1.1.1 trigger-fix PR (#184) bumped `version.rb` without refreshing the lockfile's own panda-core entry, so the auto-release job (which the fixed trigger correctly fired — the fix itself works) failed at its frozen `bundle install`. One-line lockfile sync; on merge the auto-release should complete and publish v1.1.1.