### PR TITLE
Security: only trust OAuth email when the provider verifies ownership

### DIFF
--- a/app/models/panda/core/user.rb
+++ b/app/models/panda/core/user.rb
@@ -49,6 +49,20 @@ module Panda
       }
 
       def self.find_or_create_from_auth_hash(auth_hash)
+        # Email is the cross-provider identity key, so we must only trust it
+        # when the identity provider actually attests the user owns it.
+        # Otherwise a provider that lets a user assert an arbitrary email
+        # (a generic OAuth2/OIDC/SAML strategy, or a misconfigured one) would
+        # allow matching into an existing account — an account-takeover vector.
+        unless email_verified_for_auth?(auth_hash)
+          user = new(
+            email: auth_hash.info.email.to_s.downcase,
+            name: auth_hash.info.name || "Unknown User"
+          )
+          user.errors.add(:base, "Your email address could not be verified with the identity provider. Please contact your administrator.")
+          return user
+        end
+
         user = find_by(email: auth_hash.info.email.downcase)
 
         avatar_url = auth_hash.info.image
@@ -101,6 +115,62 @@ module Panda
 
         user
       end
+
+      # Whether the provider's asserted email may be trusted as proof of
+      # ownership for this authentication.
+      #
+      # Precedence:
+      #   1. An explicit `email_verified` signal from the provider (checked in
+      #      both `info` and `extra.raw_info`) is authoritative — truthy means
+      #      verified, an explicit false means NOT verified (no fallback).
+      #   2. When the provider returns no such signal, fall back to the
+      #      `trusted_email_providers` allow-list so operators must opt a
+      #      provider in. The dev-only `developer` strategy is trusted only in
+      #      the development environment.
+      def self.email_verified_for_auth?(auth_hash)
+        signal = extract_email_verified_signal(auth_hash)
+        return truthy_verification?(signal) unless signal.nil?
+
+        provider = indifferent_lookup(auth_hash, :provider).to_s
+        return false if provider.empty?
+        return true if provider == "developer" && Rails.env.development?
+
+        trusted = Panda::Core.config.trusted_email_providers || []
+        trusted.map(&:to_s).include?(provider)
+      end
+
+      # Pull an `email_verified` value from the standard OmniAuth locations.
+      # Returns nil when the provider asserts nothing (so the caller can fall
+      # back to the trust policy), and preserves an explicit `false`.
+      def self.extract_email_verified_signal(auth_hash)
+        info = indifferent_lookup(auth_hash, :info)
+        info_signal = indifferent_lookup(info, :email_verified)
+        return info_signal unless info_signal.nil?
+
+        extra = indifferent_lookup(auth_hash, :extra)
+        raw_info = indifferent_lookup(extra, :raw_info)
+        indifferent_lookup(raw_info, :email_verified)
+      end
+
+      # OmniAuth strategies variously return booleans or strings ("true").
+      def self.truthy_verification?(value)
+        value == true || value.to_s.strip.casecmp("true").zero?
+      end
+
+      # Fetch a key from an OmniAuth::AuthHash (Hashie::Mash) or a plain Hash
+      # without losing an explicit `false` value. Returns nil when absent.
+      def self.indifferent_lookup(hash, key)
+        return nil unless hash.respond_to?(:key?)
+
+        if hash.key?(key.to_s)
+          hash[key.to_s]
+        elsif hash.key?(key.to_sym)
+          hash[key.to_sym]
+        end
+      end
+
+      private_class_method :email_verified_for_auth?, :extract_email_verified_signal,
+        :truthy_verification?, :indifferent_lookup
 
       # Admin status check
       def admin?

--- a/lib/panda/core/configuration.rb
+++ b/lib/panda/core/configuration.rb
@@ -50,7 +50,8 @@ module Panda
         :restrict_user_creation,
         :after_user_invited,
         :invite_form_content,
-        :post_authentication_redirect
+        :post_authentication_redirect,
+        :trusted_email_providers
 
       def initialize
         @user_class = "Panda::Core::User"
@@ -67,6 +68,19 @@ module Panda
         @authentication_provider_resolver = nil
         @authentication_provider_gate = nil
         @authentication_validator = nil
+        # OAuth providers whose asserted email address may be trusted as proof
+        # of ownership when the provider does NOT return an explicit
+        # `email_verified` signal. Providers that DO return the signal (e.g.
+        # Google/OIDC) are honoured regardless of this list. Operators must
+        # opt a provider in here; anything not listed (and without a verified
+        # signal) is treated as unverified to avoid account-takeover via a
+        # provider that lets users assert arbitrary emails.
+        #
+        # Defaults to the first-party providers this engine ships support for,
+        # all of which verify email ownership (Google also returns an explicit
+        # signal). A generic/self-hosted OAuth2/OIDC/SAML provider an operator
+        # adds is NOT trusted by default and must be listed here explicitly.
+        @trusted_email_providers = %i[google_oauth2 github microsoft_graph]
         @admin_path = "/admin"
         @default_theme = "default"
 

--- a/spec/models/panda/core/user_spec.rb
+++ b/spec/models/panda/core/user_spec.rb
@@ -163,6 +163,108 @@ RSpec.describe Panda::Core::User, type: :model do
 
         described_class.find_or_create_from_auth_hash(auth_hash)
       end
+
+      context "email verification" do
+        before { allow(Panda::Core::AttachAvatarService).to receive(:call) }
+
+        def auth_for(provider:, email: "victim@example.com", info: {}, extra: nil)
+          hash = {
+            provider: provider,
+            uid: "abc123",
+            info: {email: email, name: "Some User"}.merge(info)
+          }
+          hash[:extra] = extra if extra
+          OmniAuth::AuthHash.new(hash)
+        end
+
+        it "creates the user when the provider marks the email verified" do
+          auth = auth_for(provider: "google_oauth2", info: {email_verified: true})
+
+          expect {
+            user = described_class.find_or_create_from_auth_hash(auth)
+            expect(user).to be_persisted
+          }.to change(described_class, :count).by(1)
+        end
+
+        it "honours a verified signal nested under extra.raw_info" do
+          auth = auth_for(provider: "some_oidc", extra: {raw_info: {email_verified: true}})
+
+          expect {
+            described_class.find_or_create_from_auth_hash(auth)
+          }.to change(described_class, :count).by(1)
+        end
+
+        it "treats the string \"true\" as verified" do
+          auth = auth_for(provider: "some_oidc", info: {email_verified: "true"})
+
+          expect {
+            described_class.find_or_create_from_auth_hash(auth)
+          }.to change(described_class, :count).by(1)
+        end
+
+        it "rejects an explicitly unverified email without creating a user" do
+          auth = auth_for(provider: "google_oauth2", info: {email_verified: false})
+
+          expect {
+            user = described_class.find_or_create_from_auth_hash(auth)
+            expect(user).not_to be_persisted
+            expect(user.errors[:base].join).to match(/could not be verified/)
+          }.not_to change(described_class, :count)
+        end
+
+        it "does NOT match an existing account when the email is unverified" do
+          existing = described_class.create!(email: "victim@example.com", name: "Victim")
+          auth = auth_for(provider: "some_untrusted_oauth2", email: "victim@example.com")
+
+          user = described_class.find_or_create_from_auth_hash(auth)
+
+          expect(user).not_to be_persisted
+          expect(user.id).to be_nil
+          expect(existing.reload).to be_present
+        end
+
+        it "trusts a provider on the allow-list that omits the email_verified field" do
+          # github returns no email_verified signal but is opted in by default.
+          auth = auth_for(provider: "github")
+
+          expect {
+            user = described_class.find_or_create_from_auth_hash(auth)
+            expect(user).to be_persisted
+          }.to change(described_class, :count).by(1)
+        end
+
+        it "rejects a provider not on the allow-list that omits the field" do
+          auth = auth_for(provider: "some_untrusted_oauth2")
+
+          expect {
+            user = described_class.find_or_create_from_auth_hash(auth)
+            expect(user).not_to be_persisted
+          }.not_to change(described_class, :count)
+        end
+
+        it "finds an existing account when a trusted provider verifies the email" do
+          existing = described_class.create!(email: "victim@example.com", name: "Victim")
+          auth = auth_for(provider: "google_oauth2", email: "victim@example.com", info: {email_verified: true})
+
+          user = described_class.find_or_create_from_auth_hash(auth)
+
+          expect(user).to eq(existing)
+        end
+
+        it "trusts the developer strategy only in development" do
+          auth = auth_for(provider: "developer")
+
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+          expect {
+            described_class.find_or_create_from_auth_hash(auth)
+          }.not_to change(described_class, :count)
+
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+          expect {
+            described_class.find_or_create_from_auth_hash(auth)
+          }.to change(described_class, :count).by(1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

`User.find_or_create_from_auth_hash` matched/created users purely on `auth_hash.info.email`, regardless of provider, without checking whether the identity provider verified the user owns that email. A provider that lets a user assert an arbitrary email (a generic OAuth2/OIDC/SAML strategy, or a misconfigured one) could therefore be used to match into an existing account — an **account-takeover** vector, which also propagates to downstream apps that key tenant-scoped lookups off this email.

## Fix

- Honour an explicit `email_verified` signal from `info` or `extra.raw_info` (boolean `true` or string `"true"`); an explicit `false` is rejected with no fallback.
- When a provider returns no signal, fall back to a configurable `trusted_email_providers` allow-list so operators must opt providers in. Defaults to the first-party providers this engine ships (`google_oauth2`, `github`, `microsoft_graph`), all of which verify email. The dev-only `developer` strategy is trusted only in development.
- Unverified/untrusted auth returns a non-persisted `User` with an error, so `SessionsController#create` redirects to login without matching or creating an account.

No schema changes. Backward-compatible for the currently-supported providers.

## Tests

New `email verification` context in `user_spec.rb`: verified signal (info + `extra.raw_info` + string `"true"`) → created; explicit `false` → rejected; **unverified email does not match an existing account**; allow-listed provider without the field → allowed; non-listed provider → rejected; developer trusted only in development. All green (user model 43, sessions 31, auth system spec incl. Microsoft 5), standardrb clean.